### PR TITLE
Fix Makefile errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore the build and lib dirs
 build
 lib/*
+!lib/README.md
 
 # Ignore any executables
 bin/*

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ GTESTDIR := $(TEST_SRCDIR)/gtest-1.7.0
 
 $(TARGET): $(OBJECTS)
 	@echo " Linking...";
+	mkdir -p $(shell dirname $(TARGET))
 	$(CC) $^ -o $(TARGET) $(LIB) $(LFLAGS)
 	# @echo " Running..."; $(TARGET) test/sample4.json
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,5 @@
+Libraries placed in this directory will be used by our makefile when building
+the project. This directory will be given priority over system paths.
+
+Feel free to place here libraries that you don't want to install globally in
+your system.


### PR DESCRIPTION
- There is no directory called `lib` (`$(LIBDIR)`) in the repository,
  therefore `-L $(LIBDIR)` fails

- There is no `bin` directory in the repository, so `g++` fails when
  outputting `bin/runner`

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>