### PR TITLE
Fail if bin/runner is called with no option flags

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,11 +33,15 @@ long filesize(const char *);
 template <class T> void log_cjson_size(Cjson<T> &, const char *, long);
 
 bool check_arguments(int argc, char *argv[]) {
-    if (argc > 3 || argc == 1) {
+    if (argc != 3 || 
+        (strcmp(argv[1], "-r") != 0 && 
+         strcmp(argv[1], "-bp") != 0 && 
+         strcmp(argv[1], "-df") != 0)) {
         cout << "Usage" << endl;
-        cout << "runner [-rc] <file.json>" << endl;
+        cout << "runner <-r|-bp|-df> <file.json>" << endl;
         return false;
     }
+
     return true;
 }
 


### PR DESCRIPTION
The argument checks goes like this:

- If the first argument is `-r`, then pass the second argument to
  `rapidjson_usage_test()`

- If the first argument is `-bp`, then pass the second argument to
  `cjson_usage_test()`

- Else, pass the *second* argument to `cjson_usage_test()`

The usage output says:

```
runner [-rc] <file.json>
```

Which makes me believe that the option flags are indeed optional,
therefore passing a file as a first argument should work, however it
causes a segmentation fault, as `argv[2]` points to nothing.

Instead of making the arguments optional, this commit makes the first
option required.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>