### PR TITLE
Save the resulting binary document

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,11 +114,13 @@ void cjson_usage_test(char *fnarg, bool bp) {
         Cjson<BpTree> *p = cjson_bp_from_file(fnarg);
         cout << "BpTraversal creation" << endl;
         BpTraversal *tbp = new BpTraversal(p);
+        cjson_save(*p, fnarg);
     }
     else {
         Cjson<DfTree> *p = cjson_df_from_file(fnarg);
         cout << "DFTraversal creation" << endl;
         DfTraversal *tdf = new DfTraversal(p);
+        cjson_save(*p, fnarg);
      }
     // bebusy();
     // delete p;


### PR DESCRIPTION
Right now, the command-line tool does nothing. I found that there are
two commented-out function calls in `src/main.cpp`:

- `cjson_save()`: Which saves the generated document on the same path as
  the input file, but with a `.json_c` file extension
- `cjson_log()`: Which presumably logs the generated document

I couldn't make `cjson_log()` work as I get various compiler errors
about accessing class members that do not exist, so I enabled
`cjson_save()` on both the `BpTraversal` and the `DFTraversal` code
paths.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>